### PR TITLE
Fix wordpress blog link on about.md

### DIFF
--- a/about.md
+++ b/about.md
@@ -20,5 +20,5 @@ permalink: /about/
 
 **Misc**
 
-[One Third Blue](onethirdblue.wordpress.com)
+[One Third Blue](https://onethirdblue.wordpress.com)
 


### PR DESCRIPTION
The urls need https:// in their front to not be treated as relative links.